### PR TITLE
fix: use github.action_path/requirements.txt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - run: |
         python -m venv ./.venv
         . ./.venv/bin/activate
-        pip install -r requirements.txt
+        pip install -r ${{ github.action_path }}/requirements.txt
       if: steps.cache-venv.outputs.cache-hit != 'true'
       shell: bash
     - run: |


### PR DESCRIPTION
Instead of looking for `requirements.txt` in the local path of the calling workflow, this forces to look in the directory of the path of the checked out action, in context `github.action_path`. Tested at https://github.com/wdconinc/test-generate-meeting-slides.